### PR TITLE
Wy condition according to schematics

### DIFF
--- a/gebeh-core/src/ppu/mod.rs
+++ b/gebeh-core/src/ppu/mod.rs
@@ -503,9 +503,10 @@ impl Ppu {
                 ly,
                 ..
             } => {
-                // Citation:
-                // at some point in this frame the value of WY was equal to LY (checked at the start of Mode 2 only)
-                if window_y.is_none() && *dots_count == 0 && *ly == state.wy {
+                if window_y.is_none()
+                    && self.state.lcd_control.contains(LcdControl::WINDOW_ENABLE)
+                    && *ly == state.wy
+                {
                     *window_y = Some(0);
                 }
                 *dots_count += 1;

--- a/gebeh-core/src/ppu/mod.rs
+++ b/gebeh-core/src/ppu/mod.rs
@@ -496,19 +496,27 @@ impl Ppu {
             self.interrupt_part_lcd_status = value;
         }
 
+        // Pandocs says (https://gbdev.io/pandocs/Scrolling.html#window):
+        // WY condition was triggered: i.e. at some point in this frame the value of WY was equal to LY (checked at the start of Mode 2 only)
+        //
+        // However, nothing in the schematics https://github.com/msinger/dmg-schematics/blob/2829269ee7cfbb681bc10deab6f3c1ee22c940e0/dmg_cpu_b/win_detect.kicad_sch
+        // shows that the check is done at the start of Mode 2 (if my understanding is correct)
         match &mut self.step {
-            PpuStep::OamScan {
-                dots_count,
-                window_y,
-                ly,
-                ..
-            } => {
+            PpuStep::OamScan { window_y, ly, .. }
+            | PpuStep::Drawing { window_y, ly, .. }
+            | PpuStep::HorizontalBlank { window_y, ly, .. } => {
                 if window_y.is_none()
                     && self.state.lcd_control.contains(LcdControl::WINDOW_ENABLE)
                     && *ly == state.wy
                 {
                     *window_y = Some(0);
                 }
+            }
+            _ => {}
+        }
+
+        match &mut self.step {
+            PpuStep::OamScan { dots_count, .. } => {
                 *dots_count += 1;
             }
             PpuStep::Drawing {


### PR DESCRIPTION
Fixes #85 

Stumbled upon https://github.com/mgba-emu/mgba/issues/1519 (hi benderscruffy)
However the mode 0 glitch theory is strange.

Looking at the schematics:
<img width="1432" height="353" alt="image" src="https://github.com/user-attachments/assets/17cd4b58-2884-4f10-865e-dd2fff709de7" />
(from https://github.com/msinger/dmg-schematics/blob/2829269ee7cfbb681bc10deab6f3c1ee22c940e0/dmg_cpu_b/win_detect.kicad_sch)

We can see that FF40_D5 (the window enabled bit) is needed to trigger the WY condition. When checking this bit for the WY condition, the alien head bug is fixed.
Besides, I don't see any constraint on the mode to check the WY condition. According to pandocs at https://gbdev.io/pandocs/Scrolling.html#window:
> WY condition was triggered: i.e. at some point in this frame the value of WY was equal to LY (checked at the start of Mode 2 only)

So now gebeh always checks the wy condition except in VBLANK. If I don't do this, the mealybug test "m2_win_en_toggle" doesn't pass.