### PR TITLE
Fix Initial D Gaiden

### DIFF
--- a/gebeh-core/src/mbc/mbc1.rs
+++ b/gebeh-core/src/mbc/mbc1.rs
@@ -24,7 +24,8 @@ impl<T: Deref<Target = [u8]>> Mbc1<T> {
             rom,
             rom_bank: NonZeroU8::MIN,
             advanced_bank: 0,
-            ram: [0; 0x8000],
+            // Initial D Gaiden assumes that the ram is filled with 0xff
+            ram: [0xff; 0x8000],
             ram_enabled: false,
             banking_mode: BankingMode::Simple,
         }

--- a/gebeh-core/src/ppu/mod.rs
+++ b/gebeh-core/src/ppu/mod.rs
@@ -236,9 +236,20 @@ impl From<[u8; 4]> for ObjectAttribute {
 // one iteration = one dot = (1/4 M-cyle DMG)
 impl Ppu {
     pub fn set_interrupt_part_lcd_status(&mut self, value: u8) {
-        self.queued_interrupt_part_lcd_status = Some(LcdStatus::from_bits_truncate(value));
-        // Citation: It behaves as if $FF were written for one M-cycle, and then the written value were written the next M-cycle
-        self.interrupt_part_lcd_status = LcdStatus::from_bits_truncate(0xff)
+        // https://www.devrs.com/gb/files/faqs.html#GBBugs
+        // Citation: As far as has been figured out, the bug happens everytime
+        // ANYTHING (including 00) is written to the STAT register ($ff41) while
+        // the gameboy is either in HBLANK or VBLANK mode
+        if core::matches!(
+            self.step,
+            PpuStep::HorizontalBlank { .. } | PpuStep::VerticalBlankScanline { .. }
+        ) {
+            self.queued_interrupt_part_lcd_status = Some(LcdStatus::from_bits_truncate(value));
+            // Citation: It behaves as if $FF were written for one M-cycle, and then the written value were written the next M-cycle
+            self.interrupt_part_lcd_status = LcdStatus::from_bits_truncate(0xff)
+        } else {
+            self.interrupt_part_lcd_status = LcdStatus::from_bits_truncate(value)
+        }
     }
 
     pub fn get_ly(&self) -> u8 {

--- a/gebeh-core/src/ppu/renderer.rs
+++ b/gebeh-core/src/ppu/renderer.rs
@@ -124,9 +124,9 @@ impl Renderer {
         if ppu_state
             .old_lcd_control
             .contains(LcdControl::WINDOW_ENABLE)
-            && (cursor == i16::from(ppu_state.old_old_wx + 1)
+            && (cursor == i16::from(ppu_state.old_old_wx.saturating_add(1))
                 // strange race condition showed by mealybug and my Game Boy Pocket
-                || (cursor == i16::from(ppu_state.old_old_wx + 2)
+                || (cursor == i16::from(ppu_state.old_old_wx.saturating_add(2))
                     && !ppu_state
                         .old_old_lcd_control
                         .contains(LcdControl::WINDOW_ENABLE)))

--- a/tests/blargg.rs
+++ b/tests/blargg.rs
@@ -49,6 +49,8 @@ fn mem_timing_2() {
     let rom = std::fs::read("./downloads/gb-test-roms-master/mem_timing-2/mem_timing.gb").unwrap();
     let rom = rom.as_slice();
     let (_, mut mbc) = get_mbc::<_, InstantRtc>(rom).unwrap();
+    // we have to clear the ram to have a 0 terminated string in ram...
+    mbc.load_saved_ram(&[0; 0x8000]);
     let mut machine = Emulator::default();
 
     let output = loop {

--- a/tests/blargg_dmg_sound.rs
+++ b/tests/blargg_dmg_sound.rs
@@ -11,6 +11,8 @@ fn dmg_sound(name: &str) {
     .unwrap();
     let rom = rom.as_slice();
     let (_, mut mbc) = get_mbc::<_, InstantRtc>(rom).unwrap();
+    // we have to clear the ram to have a 0 terminated string in ram...
+    mbc.load_saved_ram(&[0; 0x8000]);
     let mut machine = Emulator::default();
 
     while mbc.get_ram_to_save().unwrap()[0] == 0x80


### PR DESCRIPTION
Fixes #90 

- Init mbc1 ram with 0xff
- spurious STAT interrupts only when mode = VBLANK/HBLANK
- fix overflow when wx = 255